### PR TITLE
Diktat 0.5.3 and other version updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,23 +8,19 @@ plugins {
     kotlin("multiplatform") version "1.4.32"
     kotlin("plugin.spring") version "1.4.32"
     kotlin("plugin.serialization") version "1.4.32"
-    id("org.springframework.boot") version "2.4.4"
+    id("org.springframework.boot") version "2.4.5"
     id("org.cqfn.diktat.diktat-gradle-plugin") version "0.5.3"
     id("com.palantir.git-version") version "0.12.3" apply false
 }
 
-repositories {
-    jcenter()
-}
-
 val kotlinVersion = "1.4.32"
 val serializationVersion = "1.1.0"
-val diktatVersion = "0.5.2"
+val diktatVersion = "0.5.3"
 val ktlintVersion = "0.39.0"
-val springBootVersion = "2.4.4"
+val springBootVersion = "2.4.5"
 
-val reactVersion = "17.0.1"
-val kotlinReactVersion = "17.0.1-pre.148-kotlin-1.4.30"
+val reactVersion = "17.0.2"
+val kotlinReactVersion = "17.0.2-pre.155-kotlin-1.4.32"
 
 publishing {
     publications {
@@ -44,8 +40,9 @@ tasks.withType<JavaCompile> {
 kotlin {
     js(LEGACY).browser {
         repositories {
-            jcenter()
-            maven("https://kotlin.bintray.com/js-externals")
+            mavenCentral()
+            maven("https://kotlin.bintray.com/js-externals")  // for kotlin-js-jquery
+            maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers/")
         }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/jsMain/kotlin/org/cqfn/diktat/demo/frontend/components/EditorForm.kt
+++ b/src/jsMain/kotlin/org/cqfn/diktat/demo/frontend/components/EditorForm.kt
@@ -32,7 +32,7 @@ import react.dom.label
 import react.dom.option
 import react.dom.select
 import react.dom.span
-import react.dom.textArea
+import react.dom.textarea
 import react.setState
 
 import kotlinx.browser.document
@@ -91,7 +91,7 @@ class EditorForm : RComponent<RProps, CodeFormState>() {
                             div("ace_editor ace-monokai ace_dark") {
                                 attrs.id = "editor"
                             }
-                            textArea(classes = "source") {
+                            textarea(classes = "source") {
                                 attrs.id = "source"
                                 attrs.name = "source"
                             }


### PR DESCRIPTION
### What's done:
* Updated diktat from 0.5.2 to 0.5.3
* Updated gradle from 6.8.3 to 6.9
* Updated kotlin-react from 17.0.1-pre.148-kotlin-1.4.30 to 17.0.2-pre.155-kotlin-1.4.32
* Added maven repo for kotlin-js-wrappers
* Updated spring boot from 2.4.4 to 2.4.5